### PR TITLE
fix: properly shutdown plugin when unloading

### DIFF
--- a/backend/cors_proxy.py
+++ b/backend/cors_proxy.py
@@ -9,7 +9,6 @@ from urllib.request import HTTPErrorProcessor, Request, build_opener
 
 from logger import logger
 
-
 class NoExceptionErrorProcessor(HTTPErrorProcessor):
     def http_response(self, request, response):
         # Allow redirects (3xx) to be processed by the default redirect handler,
@@ -167,8 +166,18 @@ class CORSProxy:
             logger.log(f"Starting CORS proxy server on http://{self.host}:{self.port}")
 
             # Start the server in a thread
-            self.server_thread = threading.Thread(target=self.server.serve_forever)
-            self.server_thread.daemon = True
+            def serve_with_logging():   
+                try:
+                    logger.log("serve_with_logging starting...")
+                    self.server.serve_forever()
+                    logger.log("serve_with_logging ended")
+                except Exception as e:
+                    logger.log(f"CORS proxy server error: {e}")
+                finally:
+                    logger.log("CORS proxy server thread ending")
+            
+            self.server_thread = threading.Thread(target=serve_with_logging)
+            self.server_thread.daemon = False
             self.server_thread.start()
 
             return True
@@ -179,9 +188,27 @@ class CORSProxy:
     def stop(self):
         """Stop the proxy server"""
         if self.server:
-            logger.log("Stopping proxy server")
-            self.server.shutdown()
-            self.server.server_close()
+            logger.log("Stopping CORS proxy server...")
+            
+            try:
+                self.server.shutdown()
+            except Exception as e:
+                logger.log(f"Error during server shutdown: {e}")
+            
+            try:
+                self.server.server_close()
+            except Exception as e:
+                logger.log(f"Error closing server socket: {e}")
+            
+            # wait for server thread to finish properly
+            if self.server_thread and self.server_thread.is_alive():
+                logger.log("Waiting for proxy server thread to finish...")
+                self.server_thread.join(timeout=10) 
+
+                if self.server_thread.is_alive():
+                    logger.error("Proxy server thread did not finish within timeout!")
+            
+            logger.log("CORS proxy server shutdown complete")
             self.server = None
             self.server_thread = None
             return True

--- a/backend/websocket/client_manager.py
+++ b/backend/websocket/client_manager.py
@@ -71,3 +71,24 @@ class ClientManager:
     def has_webkit_clients(self) -> bool:
         """Check if any webkit clients are connected."""
         return len(self._webkit_clients) > 0
+    
+    def disconnect_all_clients(self):
+        if self._frontend_client:
+            try:
+                websocket = getattr(self._frontend_client, 'websocket', None)
+                if websocket and hasattr(websocket, 'close'):
+                    websocket.close()
+            except Exception:
+                pass
+            finally:
+                self._frontend_client = None
+        
+        for client in self._webkit_clients:
+            try:
+                websocket = getattr(client, 'websocket', None)
+                if websocket and hasattr(websocket, 'close'):
+                    websocket.close()
+            except Exception:
+                pass
+        
+        self._webkit_clients.clear()


### PR DESCRIPTION
In its current state, the plugin fails to shut down properly, leaving numerous dangling references and active threads that crash the Python VM, along with Millennium and, by extension, Steam. This PR addresses those issues. 

**Note:** This PR has not been fully tested, and there may be additional places that require verification (as I don't really know the full extent of the plugin and what does what).