### PR TITLE
Add websockets to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+websockets


### PR DESCRIPTION
websockets is not a python builtin library, it only existed initially because Millennium depended on it. Now that Millennium is being ported from python to lua, the core of Millennium is no longer written in python - meaning it no longer depends on websockets.