### PR TITLE
fix: toolbar puzzle piece icon invisible in Steam themes

### DIFF
--- a/frontend/components/ToolbarExtensionManager/ToolbarManagerButton.tsx
+++ b/frontend/components/ToolbarExtensionManager/ToolbarManagerButton.tsx
@@ -33,7 +33,7 @@ export function ToolbarManagerButton(): React.JSX.Element {
       onClick={openExtensionsContextMenu}
       title="Extensions"
     >
-      <IoExtensionPuzzleOutline color="gray" size={17} style={{ padding: 0 }} />
+      <IoExtensionPuzzleOutline size={17} style={{ padding: 0 }} />
     </button>
   );
 }

--- a/public/extendium.scss
+++ b/public/extendium.scss
@@ -113,6 +113,9 @@ $secondary-text-color: rgba(255, 255, 255, 0.6);
 
     svg {
       display: block !important;
+      color: $primary-text-color;
+      stroke: $primary-text-color;
+      fill: currentColor;
     }
 
     .update-dot {


### PR DESCRIPTION
## Summary

The puzzle piece icon (`IoExtensionPuzzleOutline`) in the URL bar toolbar was invisible — Steam's CSS overrides `color` on elements inside buttons, causing the SVG's `stroke="currentColor"` to resolve to an invisible value. This is the same class of issue as #37f54f7 (invisible extension buttons on Fluenty theme), which only fixed `display`.

- Force `color`, `stroke`, and `fill` on `.extension-button svg` to use `$primary-text-color` (white 90% opacity), overriding Steam theme CSS
- Remove hardcoded `color="gray"` from `IoExtensionPuzzleOutline` so the CSS override takes effect instead of being masked by the inline style

## Testing

Tested on Millennium 3.0.0-beta 24.

## AI Usage

This PR was developed with assistance from Claude Code (Claude Opus 4.7). The analysis, diagnosis, and fix were AI-assisted.